### PR TITLE
Improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         }
     },
     "autoload-dev": {
+        "psr-4": {
+            "DanielDeWit\\LaravelIdeHelperHookPaperclip\\Tests\\": "tests"
+        }
     },
     "scripts": {
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,9 @@
          colors="true"
 >
     <testsuites>
+        <testsuite name="Integration">
+            <directory suffix="Test.php">./tests/Integration</directory>
+        </testsuite>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>

--- a/src/Hooks/PaperclipHook.php
+++ b/src/Hooks/PaperclipHook.php
@@ -6,9 +6,12 @@ namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Hooks;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Barryvdh\LaravelIdeHelper\Contracts\ModelHookInterface;
+use Czim\FileHandling\Contracts\Support\RawContentInterface;
+use Czim\FileHandling\Storage\File\SplFileInfoStorableFile;
 use Czim\Paperclip\Contracts\AttachableInterface;
 use Czim\Paperclip\Contracts\AttachmentInterface;
 use Illuminate\Database\Eloquent\Model;
+use SplFileInfo;
 
 class PaperclipHook implements ModelHookInterface
 {
@@ -19,14 +22,18 @@ class PaperclipHook implements ModelHookInterface
         }
 
         foreach($model->getAttachedFiles() as $index => $attachment) {
-            $command->setProperty(
-                $index,
-                '\\' . AttachmentInterface::class,
-                true,
-                true,
-                '',
-                false,
-            );
+            $command->setProperty($index, $this->getTypes(), true, true, '', false);
         }
+    }
+
+    protected function getTypes(): string
+    {
+        return implode('|', [
+            '\\' . AttachmentInterface::class,
+            '\\' . SplFileInfo::class,
+            '\\' . SplFileInfoStorableFile::class,
+            '\\' . RawContentInterface::class,
+            'string',
+        ]);
     }
 }

--- a/src/Hooks/PaperclipHook.php
+++ b/src/Hooks/PaperclipHook.php
@@ -21,8 +21,8 @@ class PaperclipHook implements ModelHookInterface
             return;
         }
 
-        foreach($model->getAttachedFiles() as $index => $attachment) {
-            $command->setProperty($index, $this->getTypes(), true, true, '', false);
+        foreach($model->getAttachedFiles() as $name => $attachment) {
+            $command->setProperty($name, $this->getTypes(), true, true, '', false);
         }
     }
 

--- a/src/Providers/LaravelIdeHelperHookPaperclipServiceProvider.php
+++ b/src/Providers/LaravelIdeHelperHookPaperclipServiceProvider.php
@@ -3,6 +3,7 @@
 namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Providers;
 
 use DanielDeWit\LaravelIdeHelperHookPaperclip\Hooks\PaperclipHook;
+use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelIdeHelperHookPaperclipServiceProvider extends ServiceProvider
@@ -13,10 +14,11 @@ class LaravelIdeHelperHookPaperclipServiceProvider extends ServiceProvider
             return;
         }
 
-        config([
-            'ide-helper.model_hooks' => array_merge([
-                PaperclipHook::class,
-            ], config('ide-helper.model_hooks', [])),
-        ]);
+        /** @var Config $config */
+        $config = $this->app->get('config');
+
+        $config->set('ide-helper.model_hooks', array_merge([
+            PaperclipHook::class,
+        ], $config->get('ide-helper.model_hooks', [])));
     }
 }

--- a/tests/Integration/LaravelIdeHelperHookPaperclipServiceProviderTest.php
+++ b/tests/Integration/LaravelIdeHelperHookPaperclipServiceProviderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\Integration;
+
+use DanielDeWit\LaravelIdeHelperHookPaperclip\Hooks\PaperclipHook;
+use DanielDeWit\LaravelIdeHelperHookPaperclip\Providers\LaravelIdeHelperHookPaperclipServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class LaravelIdeHelperHookPaperclipServiceProviderTest extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            LaravelIdeHelperHookPaperclipServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_the_paperclip_hook_to_the_config(): void
+    {
+        static::assertContains(PaperclipHook::class, config('ide-helper.model_hooks'));
+    }
+}

--- a/tests/Unit/Hooks/PaperclipHookTest.php
+++ b/tests/Unit/Hooks/PaperclipHookTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\Unit;
+namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\Unit\Hooks;
 
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Czim\Paperclip\Contracts\AttachmentInterface;

--- a/tests/Unit/PaperclipHookTest.php
+++ b/tests/Unit/PaperclipHookTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\Unit;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Czim\Paperclip\Contracts\AttachmentInterface;
+use DanielDeWit\LaravelIdeHelperHookPaperclip\Hooks\PaperclipHook;
+use DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\stubs\ModelWithAttachment;
+use Illuminate\Database\Eloquent\Model;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class PaperclipHookTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @test
+     */
+    public function it_writes_paperclip_properties(): void
+    {
+        /** @var ModelsCommand|MockInterface $command */
+        $command = Mockery::mock(ModelsCommand::class)
+            ->shouldReceive('setProperty')
+            ->with(
+                'foobar',
+                '\\Czim\\Paperclip\\Contracts\\AttachmentInterface|\\SplFileInfo|\\Czim\\FileHandling\\Storage\\File\\SplFileInfoStorableFile|\\Czim\\FileHandling\\Contracts\\Support\\RawContentInterface|string',
+                true,
+                true,
+                '',
+                false,
+            )
+            ->getMock();
+
+        /** @var ModelWithAttachment|MockInterface $model */
+        $model = Mockery::mock(ModelWithAttachment::class)
+            ->shouldReceive('getAttachedFiles')
+            ->andReturn([
+                'foobar' => Mockery::mock(AttachmentInterface::class),
+            ])
+            ->getMock();
+
+        (new PaperclipHook())->run($command, $model);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_write_paperclip_properties_if_the_model_is_not_attachable(): void
+    {
+        /** @var ModelsCommand|MockInterface $command */
+        $command = Mockery::mock(ModelsCommand::class)
+            ->shouldNotReceive('setProperty')
+            ->getMock();
+
+        (new PaperclipHook())->run($command, Mockery::mock(Model::class));
+    }
+}

--- a/tests/Unit/Providers/LaravelIdeHelperHookPaperclipServiceProviderTest.php
+++ b/tests/Unit/Providers/LaravelIdeHelperHookPaperclipServiceProviderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\Unit\Providers;
+
+use DanielDeWit\LaravelIdeHelperHookPaperclip\Hooks\PaperclipHook;
+use DanielDeWit\LaravelIdeHelperHookPaperclip\Providers\LaravelIdeHelperHookPaperclipServiceProvider;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Foundation\Application;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class LaravelIdeHelperHookPaperclipServiceProviderTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var LaravelIdeHelperHookPaperclipServiceProvider
+     */
+    protected $provider;
+
+    /**
+     * @var Application|MockInterface
+     */
+    protected $app;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app      = Mockery::mock(Application::class);
+        $this->provider = new LaravelIdeHelperHookPaperclipServiceProvider($this->app);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_the_paperclip_hook_to_the_config(): void
+    {
+        /** @var Config|MockInterface $config */
+        $config = Mockery::mock(Config::class)
+            ->shouldReceive('get')
+            ->with('ide-helper.model_hooks', [])
+            ->andReturn([])
+            ->getMock()
+            ->shouldReceive('set')
+            ->with('ide-helper.model_hooks', [PaperclipHook::class])
+            ->getMock();
+
+        $this->app->shouldReceive('isProduction')->andReturnFalse();
+        $this->app->shouldReceive('get')->with('config')->andReturn($config);
+
+        $this->provider->register();
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_add_the_paperclip_hook_to_the_config_when_in_production(): void
+    {
+        $this->app->shouldReceive('isProduction')->andReturnTrue();
+        $this->app->shouldNotReceive('get')->with('config');
+
+        $this->provider->register();
+    }
+}

--- a/tests/stubs/ModelWithAttachment.php
+++ b/tests/stubs/ModelWithAttachment.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DanielDeWit\LaravelIdeHelperHookPaperclip\Tests\stubs;
+
+use Czim\Paperclip\Contracts\AttachableInterface;
+use Czim\Paperclip\Model\PaperclipTrait;
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithAttachment extends Model implements AttachableInterface
+{
+    use PaperclipTrait;
+}


### PR DESCRIPTION
### Changes

#### Model hook property type
Even-though the type of the attachment property is only `Czim\Paperclip\Contracts\AttachmentInterface` when getting, there are multiple possible types when setting the property. These types are now included.

#### Test suite
No project/package is complete without a test suite, how small it might be. It now has 100% coverage 😁